### PR TITLE
fix style of blobs in about section

### DIFF
--- a/src/shamanic/components/cubeAbout2/cubeAbout2.jsx
+++ b/src/shamanic/components/cubeAbout2/cubeAbout2.jsx
@@ -13,26 +13,20 @@ const CubeAbout2 = (props) => {
 
         return (<Container  className="CubeAbout2">
             <Row>
-            <Col xs={12} md={12} >
                <h2>
                {  storage.about.title } 
                </h2>
-            </Col>
-        
-            <Col xs={12} md={8} >
-                <p>
-                {  storage.about.text1 }<br/>
-                {  storage.about.text2 } <br/>
-                {  storage.about.text3 }
-                </p>
-                    
-            </Col>
-           
-            <Col xs={12} md={4} >
+                
+                <section className="shamanicBlob">
+                        <p>
+                        {  storage.about.text1 }<br/>
+                        {  storage.about.text2 } <br/>
+                        {  storage.about.text3 }
+                        </p>
+                </section>
 
                 <img src={ sandra } alt='sandra' className='avatar' />
             
-            </Col>
             </Row>
         </Container>)
 }

--- a/src/shamanic/components/cubeAbout2/cubeAbout2.jsx
+++ b/src/shamanic/components/cubeAbout2/cubeAbout2.jsx
@@ -12,22 +12,26 @@ const storage = Storage()
 const CubeAbout2 = (props) => {
 
         return (<Container  className="CubeAbout2">
-            <Row>
+
                <h2>
-               {  storage.about.title } 
+               {  storage.about.title }
                </h2>
-                
+
                 <section className="shamanicBlob">
-                        <p>
-                        {  storage.about.text1 }<br/>
-                        {  storage.about.text2 } <br/>
-                        {  storage.about.text3 }
-                        </p>
+                        <div class="shamanicText">
+                          <p>
+                          {  storage.about.text1 }
+                          <br/><br/>
+                          {  storage.about.text2 }
+                          <br/><br/>
+                          {  storage.about.text3 }
+                          </p>
+                        </div>
                 </section>
 
                 <img src={ sandra } alt='sandra' className='avatar' />
-            
-            </Row>
+
+
         </Container>)
 }
 

--- a/src/shamanic/components/cubeAbout2/cubeAbout2Style.css
+++ b/src/shamanic/components/cubeAbout2/cubeAbout2Style.css
@@ -1,29 +1,50 @@
-
-.CubeAbout2 p{
-    max-width: 500px;
-    padding-top: 40px;
-    padding-left: 20px;
+.CubeAbout2 {
+  min-height: 120vw;
 }
 
-.CubeAbout2 h2{
+.CubeAbout2 h2 {
+    margin-top: 12vw;
+    margin-right: 19vw;
     text-align: right;
-    padding-bottom: 100px;
 }
 
-
-
-.CubeAbout2 .avatar{
-    position: relative;
-    bottom: -450px;
-    width: 500px;
+.CubeAbout2 .shamanicBlob {
+  background-image: url('../../img/AboutBackground.svg');
+  background-size: contain;
+  background-repeat: no-repeat;
+  height: 92vw;
+  display: flex;
+  align-items: center;
 }
 
+.CubeAbout2 .shamanicText {
+  width: 40vw;
+}
 
+.CubeAbout2 .shamanicText p {
+  padding-left: 2vw;
+  font-size: 2.5vw !important;
+}
+
+/* To avoid clipping the blob's border at medium screen sizes */
+@media only screen and (max-width: 1035px) {
+  .CubeAbout2 .shamanicText p {
+    font-size: 1.8vw !important;
+  }
+}
 
 .CubeAbout2.container{
-    background-image: url('../../img/AboutBackground.svg') !important;
-    background-size: contain !important;
-    background-repeat: no-repeat !important;
-    min-height: 1200px !important;
+    /* min-height: 1200px; */
+    margin: 0;
+    padding: 0;
+    max-width: 100vw;
+}
 
+
+.CubeAbout2 .avatar {
+    position: relative;
+    width: 50vw;
+    margin: 0;
+    margin-top: -44vw;
+    float: right;
 }

--- a/src/shamanic/page02.jsx
+++ b/src/shamanic/page02.jsx
@@ -36,7 +36,7 @@ function Page01( props ) {
              <CubeBanner />
         </section>
 
-        <section  style={ {  background:'#fff', padding:'50px', height:'1200px'  } } id='sectionB'>
+        <section  style={ {  background:'#fff', height:'1200px'  } } id='sectionB'>
              <CubeAbout2 />
         </section>
 

--- a/src/shamanic/page02.jsx
+++ b/src/shamanic/page02.jsx
@@ -36,7 +36,7 @@ function Page01( props ) {
              <CubeBanner />
         </section>
 
-        <section  style={ {  background:'#fff', height:'1200px'  } } id='sectionB'>
+        <section id='sectionB'>
              <CubeAbout2 />
         </section>
 

--- a/src/shamanic/page02.jsx
+++ b/src/shamanic/page02.jsx
@@ -17,21 +17,21 @@ const storage = Storage()
 function Page01( props ) {
 
      const get =  props.location.pathname.split('/')
-     const sessionID = get[2] 
+     const sessionID = get[2]
 
      if(sessionStorage.getItem('session')==null){
           props.history.push('/')
      }
 
 
-     return ( 
+     return (
 
       <React.Fragment>
-     <div id="page02">
+     <div style={ {  overflow:'hidden' } } id="page02">
         <section className="Header">
              <Header />
         </section>
-       
+
         <section  style={ {  background:'#FDF7EB', padding:'50px'  } } id='sectionA'>
              <CubeBanner />
         </section>
@@ -47,19 +47,19 @@ function Page01( props ) {
         <section  style={ {  background:'#fff', padding:'50px'  } } id='sectionA'>
              <CubeBonuses />
         </section>
-        
+
         <section className="section06">
              <CubeIncludes />
         </section>
-       
+
         <section className="Footer">
              <Footer />
         </section>
         </div>
-        </React.Fragment> 
+        </React.Fragment>
 
      )
-        
+
 }
 
 export default withRouter(Page01)


### PR DESCRIPTION
restyles the about section on the 2nd page so that the blobs and text are all proportionally sized. Works for 800px and larger; we still need to implement the mobile version.

### Before:
<img width="1008" alt="Screen Shot 2020-05-20 at 9 23 42 PM" src="https://user-images.githubusercontent.com/21048592/82523202-505f5c00-9ae0-11ea-81ad-515c55f4c35e.png">
<img width="503" alt="Screen Shot 2020-05-20 at 9 24 17 PM" src="https://user-images.githubusercontent.com/21048592/82523208-548b7980-9ae0-11ea-8ecb-c8ff4fea6935.png">

### After:
<img width="1007" alt="Screen Shot 2020-05-20 at 9 25 44 PM" src="https://user-images.githubusercontent.com/21048592/82523259-843a8180-9ae0-11ea-9000-541dd70f2cf8.png">
<img width="1007" alt="Screen Shot 2020-05-20 at 9 25 56 PM" src="https://user-images.githubusercontent.com/21048592/82523265-88ff3580-9ae0-11ea-8d53-c1bcff91f4bd.png">
